### PR TITLE
FISH-6023 Reduce the log level in our JAX-RS extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>fish.payara.ecosystem.jaxrs</groupId>
     <artifactId>rest-ssl-configuration</artifactId>
-    <version>1.2-SNAPSHOT</version>
+    <version>1.3-SNAPSHOT</version>
 
     <repositories>
         <repository>

--- a/src/main/java/fish/payara/ecosystem/jaxrs/client/ssl/ClientBuilderExtension.java
+++ b/src/main/java/fish/payara/ecosystem/jaxrs/client/ssl/ClientBuilderExtension.java
@@ -162,7 +162,7 @@ public class ClientBuilderExtension extends ClientBuilder {
                 .getProperty(PayaraConstants.JAXRS_CLIENT_CERTIFICATE_ALIAS);
         if (objectProperty instanceof String) {
             String alias = (String) objectProperty;
-            logger.log(Level.INFO,
+            logger.log(Level.FINE,
                     String.format("The alias: %s is available from the ClientBuilder configuration", alias));
             SSLContext customSSLContext = buildSSlContext(alias);
 


### PR DESCRIPTION
Currently, the severity level INFO causing log file pollution. So that the change is decreasing the severity level from INFO to FINE for tracing information only purposes