### PR TITLE
FISH-7206 Update for Payara 6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 
     <groupId>fish.payara.ecosystem.jaxrs</groupId>
     <artifactId>rest-ssl-configuration</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
 
     <name>Ecosystem - Payara REST SSL Configuration</name>
 
@@ -59,30 +59,30 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
 
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
         <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
         <maven.javadoc.plugin.version>3.3.2</maven.javadoc.plugin.version>
         <maven.deploy.plugin.version>3.0.0-M2</maven.deploy.plugin.version>
         <maven.enforcer.plugin.version>3.0.0</maven.enforcer.plugin.version>
-        <maven.enforcer.plugin.java.limit>1.9</maven.enforcer.plugin.java.limit>
+        <maven.enforcer.plugin.java.limit>12</maven.enforcer.plugin.java.limit>
         <maven.enforcer.plugin.require.maven>3.6</maven.enforcer.plugin.require.maven>
         <maven.gpg.plugin.version>3.0.1</maven.gpg.plugin.version>
 
-        <payara.api.version>5.2022.1</payara.api.version>
-        <payara.internals.version>5.2020.5</payara.internals.version>
+        <payara.api.version>6.2023.2</payara.api.version>
+        <payara.internals.version>6.2023.2</payara.internals.version>
 
-        <jersey.version>2.26</jersey.version>
-        <microprofile.version>4.0.1</microprofile.version>
+        <jersey.version>3.1.0-M8.payara-p1</jersey.version>
+        <microprofile.version>6.0</microprofile.version>
         <junit.version>4.12</junit.version>
         <mockito.version>2.2.6</mockito.version>
-        <jakarta.ws.rs-api.version>2.1.6</jakarta.ws.rs-api.version>
+        <jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
 
         <docs.phase>deploy</docs.phase>
-        <java.version>1.8</java.version>
-        <javaee.version>8</javaee.version>
+        <java.version>11</java.version>
+        <javaee.version>10</javaee.version>
 
         <gpg.keyname>Payara-CI</gpg.keyname>
     </properties>
@@ -146,13 +146,13 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.internal.common</groupId>
+            <groupId>fish.payara.server.core.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${payara.internals.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.internal.security</groupId>
+            <groupId>fish.payara.server.core.security</groupId>
             <artifactId>security</artifactId>
             <version>${payara.internals.version}</version>
             <scope>provided</scope>

--- a/src/main/java/fish/payara/ecosystem/jaxrs/client/ssl/ClientBuilderExtension.java
+++ b/src/main/java/fish/payara/ecosystem/jaxrs/client/ssl/ClientBuilderExtension.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021-2023 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -48,9 +48,9 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509KeyManager;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.core.Configuration;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Configuration;
 import java.io.IOException;
 import java.net.Socket;
 import java.security.KeyStore;

--- a/src/test/java/fish/payara/ecosystem/jaxrs/client/ssl/ClientBuilderExtensionTest.java
+++ b/src/test/java/fish/payara/ecosystem/jaxrs/client/ssl/ClientBuilderExtensionTest.java
@@ -52,7 +52,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
-import javax.ws.rs.client.Client;
+import jakarta.ws.rs.client.Client;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;


### PR DESCRIPTION
Aligned for MicroProfile 6 in the upcoming 6.2023.3 release.
A scan of the dependencies being pulled in from Payara internals (`internal-api` and `security`) show them not using MicroProfile, so they Should™ be fine as the previously published version.